### PR TITLE
fix docker user json output

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -65,7 +65,7 @@ check_1_4() {
   info "$check_1_4"
   for u in $docker_users; do
     info "     * $u"
-    logjson "1.4" "$u"
+    logjson "1.4" "INFO: $u"
   done
   currentScore=$((currentScore + 0))
 }


### PR DESCRIPTION
This prints out the docker users in a similar fashion to the other tests, including `INFO` rather than just the system command output.